### PR TITLE
fix: handle API error responses before deserializing typed structs (v2.0.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,7 +770,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "itylos-cli"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itylos-cli"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2024"
 authors = ["Kerki", "Mehdi"]
 description = "Sovereign ephemeral messaging CLI with local AES-256-GCM encryption and burn-on-read semantics."

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <a href="https://github.com/kerk99/itylos-cli/releases"><img src="https://img.shields.io/github/v/release/kerk99/itylos-cli" alt="Release"></a>
+  <a href="https://crates.io/crates/itylos-cli"><img src="https://img.shields.io/crates/v/itylos-cli.svg" alt="crates.io"></a>
 </p>
 
 <p align="center">

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -3,7 +3,7 @@ use reqwest::blocking::Client;
 use std::time::Duration;
 
 use crate::types::{
-    API_BURN, API_CREATE, API_FETCH, BurnReq, BurnRes, CreateReq, CreateRes, FetchRes,
+    API_BURN, API_CREATE, API_FETCH, ApiErrorRes, BurnReq, BurnRes, CreateReq, CreateRes, FetchRes,
 };
 
 pub struct ItylosApi {
@@ -27,13 +27,17 @@ impl ItylosApi {
             .send()
             .context("Erreur reseau")?;
         let status = response.status();
-        let body: CreateRes = response.json().context("reponse create invalide")?;
         if !status.is_success() {
+            let err: ApiErrorRes = response.json().unwrap_or(ApiErrorRes {
+                success: false,
+                error: Some(format!("Erreur API HTTP {status}")),
+            });
             bail!(
-                body.error
+                err.error
                     .unwrap_or_else(|| format!("Erreur API HTTP {status}"))
             );
         }
+        let body: CreateRes = response.json().context("reponse create invalide")?;
         Ok(body)
     }
 
@@ -45,13 +49,17 @@ impl ItylosApi {
             .send()
             .context("Erreur reseau")?;
         let status = response.status();
-        let body: FetchRes = response.json().context("reponse fetch invalide")?;
         if !status.is_success() {
+            let err: ApiErrorRes = response.json().unwrap_or(ApiErrorRes {
+                success: false,
+                error: Some(format!("Erreur API HTTP {status}")),
+            });
             bail!(
-                body.error
+                err.error
                     .unwrap_or_else(|| format!("Erreur API HTTP {status}"))
             );
         }
+        let body: FetchRes = response.json().context("reponse fetch invalide")?;
         Ok(body)
     }
 
@@ -66,14 +74,17 @@ impl ItylosApi {
             .send()
             .context("Erreur reseau")?;
         let status = response.status();
-        let body: BurnRes = response.json().context("reponse burn invalide")?;
         if !status.is_success() {
+            let err: ApiErrorRes = response.json().unwrap_or(ApiErrorRes {
+                success: false,
+                error: Some(format!("Erreur API HTTP {status}")),
+            });
             bail!(
-                body.error
-                    .clone()
+                err.error
                     .unwrap_or_else(|| format!("Erreur API HTTP {status}"))
             );
         }
+        let body: BurnRes = response.json().context("reponse burn invalide")?;
         Ok(body)
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-pub const VERSION: &str = "v2.0.1";
+pub const VERSION: &str = "v2.0.2";
 pub const DOMAIN: &str = "https://itylos.com";
 pub const API_CREATE: &str = "https://itylos.com/api/v2/create_secret";
 pub const API_FETCH: &str = "https://itylos.com/api/v2/fetch_secret";
@@ -48,6 +48,13 @@ pub struct CreateReq {
     pub pwd_salt: Option<String>,
 }
 
+/// Generic error response from the server (429, 404, 410, 500, etc.)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiErrorRes {
+    pub success: bool,
+    pub error: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateRes {
     pub success: bool,
@@ -63,9 +70,11 @@ pub struct FetchRes {
     pub success: bool,
     pub payload: Option<String>,
     pub aad_hash: Option<String>,
+    #[serde(default)]
     pub has_password: bool,
     pub pwd_salt: Option<String>,
     pub expires_at: Option<String>,
+    #[serde(default)]
     pub ttl: u64,
     pub error: Option<String>,
 }


### PR DESCRIPTION
## Summary

The CLI crashes with `reponse fetch invalide` when the server returns an HTTP error (429, 404, 410, 500) because it tries to deserialize the error JSON into typed structs before checking the HTTP status code.

Error responses only contain `{success, error}`, but `FetchRes` requires `has_password: bool` and `ttl: u64` — serde fails with a cryptic message instead of showing the actual server error.

## Fix

- Add `ApiErrorRes` struct for lightweight error deserialization
- Check HTTP status **before** parsing response body in all 3 API methods
- Add `#[serde(default)]` on `FetchRes.has_password` and `FetchRes.ttl` as safety net
- Add crates.io badge to README
- Version bump: 2.0.1 → 2.0.2

## Before / After

| Scenario | Before (2.0.1) | After (2.0.2) |
|---|---|---|
| Rate limited (429) | `[ERROR] reponse fetch invalide` | `[ERROR] Trop de requetes. Reessayez plus tard.` |
| Secret not found (404) | `[ERROR] reponse fetch invalide` | `[ERROR] Secret introuvable, expire ou deja detruit.` |
| Secret expired (410) | `[ERROR] reponse fetch invalide` | `[ERROR] Ce secret a expire et n'est plus disponible.` |
| Server error (500) | `[ERROR] reponse fetch invalide` | `[ERROR] Une erreur interne...` |
| Non-JSON response (HTML) | `[ERROR] reponse fetch invalide` | `[ERROR] Erreur API HTTP 401 Unauthorized` |

## Files changed

- `Cargo.toml` / `Cargo.lock` — version bump to 2.0.2
- `src/types.rs` — add `ApiErrorRes`, add `#[serde(default)]` on `FetchRes` fields
- `src/network/mod.rs` — check status before parsing in all 3 methods
- `README.md` — add crates.io badge

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — 29/29 tests pass
- [x] Published to crates.io as v2.0.2

Authored by: Julien GELEE (@Krigsexe)