### PR TITLE
feat: add password protection for capsules (v2.0.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,6 +328,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -528,6 +529,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -770,7 +780,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "itylos-cli"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -780,6 +790,8 @@ dependencies = [
  "console",
  "ed25519-dalek",
  "hex",
+ "hmac",
+ "pbkdf2",
  "rand 0.8.5",
  "regex",
  "reqwest",
@@ -878,6 +890,15 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itylos-cli"
-version = "2.0.2"
+version = "2.0.3"
 edition = "2024"
 authors = ["Kerki", "Mehdi"]
 description = "Sovereign ephemeral messaging CLI with local AES-256-GCM encryption and burn-on-read semantics."
@@ -23,6 +23,8 @@ colored = "=2.2.0"
 console = "=0.15.11"
 ed25519-dalek = { version = "=2.2.0", features = ["rand_core"] }
 hex = "=0.4.3"
+hmac = "=0.12.1"
+pbkdf2 = { version = "=0.12.2", default-features = false }
 rand = "=0.8.5"
 regex = "=1.11.3"
 reqwest = { version = "=0.12.23", default-features = false, features = ["blocking", "json", "rustls-tls"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,6 +37,9 @@ pub enum Commands {
         /// Fichier a joindre.
         #[arg(short = 'f')]
         file: Option<PathBuf>,
+        /// Proteger la capsule avec un mot de passe.
+        #[arg(short = 'p', long = "password")]
+        password: bool,
     },
     /// Dechiffre une capsule localement puis demande sa destruction serveur.
     Read { url: String },
@@ -65,6 +68,7 @@ mod tests {
                 text,
                 duration,
                 file,
+                ..
             }) => {
                 assert_eq!(text.as_deref(), Some("secret"));
                 assert_eq!(duration, "1h");
@@ -83,6 +87,7 @@ mod tests {
                 text,
                 duration,
                 file,
+                ..
             }) => {
                 assert_eq!(text, None);
                 assert_eq!(duration, "24h");

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -8,6 +8,8 @@ use base64::{
     engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
 };
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use hmac::Hmac;
+use pbkdf2::pbkdf2;
 use rand::RngCore;
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
@@ -20,6 +22,7 @@ pub struct EncryptionOutcome {
     pub payload: String,
     pub aad_hash_hex: String,
     pub key_fragment: String,
+    pub salt_b64: Option<String>,
 }
 
 pub fn generate_url_key() -> Result<Zeroizing<Vec<u8>>> {
@@ -35,6 +38,37 @@ pub fn encode_url_key(url_key: &[u8]) -> String {
 pub fn derive_key(url_key: &[u8]) -> Zeroizing<Vec<u8>> {
     let digest = Sha256::digest(url_key);
     Zeroizing::new(digest.to_vec())
+}
+
+/// Derive a 256-bit key from a password + salt using PBKDF2-HMAC-SHA256 (300k iterations).
+/// Compatible with the JS frontend (crypto.js derivePasswordKey fallback).
+pub fn derive_password_key(password: &str, salt: &[u8]) -> Result<Zeroizing<Vec<u8>>> {
+    let mut derived = Zeroizing::new(vec![0u8; 32]);
+    pbkdf2::<Hmac<Sha256>>(password.as_bytes(), salt, 300_000, &mut derived)
+        .map_err(|_| ItylosError::Message("erreur PBKDF2".to_string()))?;
+    Ok(derived)
+}
+
+/// Derive final AES key from url_key + password: SHA-256(url_key || pwd_key).
+/// Compatible with the JS frontend (crypto.js encryptSecret with password).
+pub fn derive_combined_key(
+    url_key: &[u8],
+    password: &str,
+    salt: &[u8],
+) -> Result<Zeroizing<Vec<u8>>> {
+    let pwd_key = derive_password_key(password, salt)?;
+    let mut combined = Vec::with_capacity(url_key.len() + pwd_key.len());
+    combined.extend_from_slice(url_key);
+    combined.extend_from_slice(&pwd_key);
+    let digest = Sha256::digest(&combined);
+    combined.zeroize();
+    Ok(Zeroizing::new(digest.to_vec()))
+}
+
+pub fn generate_salt() -> Vec<u8> {
+    let mut salt = vec![0u8; 16];
+    rand::rngs::OsRng.fill_bytes(&mut salt);
+    salt
 }
 
 pub fn build_aad(ttl: u64) -> Result<Vec<u8>> {
@@ -72,13 +106,24 @@ pub fn pad_content(content: &str) -> Result<PaddedPayload> {
     })
 }
 
-pub fn encrypt_local(message_json: &str, ttl: u64) -> Result<EncryptionOutcome> {
+pub fn encrypt_local_with_password(
+    message_json: &str,
+    ttl: u64,
+    password: Option<&str>,
+) -> Result<EncryptionOutcome> {
     let url_key = generate_url_key()?;
     let key_fragment = encode_url_key(&url_key);
     let payload = pad_content(message_json)?;
     let plaintext_json = serde_json::to_vec(&payload).context("erreur de serialisation JSON")?;
     let mut plaintext = Zeroizing::new(plaintext_json);
-    let final_key = derive_key(&url_key);
+
+    let (final_key, salt) = if let Some(pwd) = password {
+        let salt = generate_salt();
+        let key = derive_combined_key(&url_key, pwd, &salt)?;
+        (key, Some(salt))
+    } else {
+        (derive_key(&url_key), None)
+    };
 
     let cipher = Aes256Gcm::new_from_slice(&final_key).context("erreur AES")?;
     let mut nonce_bytes = [0u8; 12];
@@ -105,10 +150,21 @@ pub fn encrypt_local(message_json: &str, ttl: u64) -> Result<EncryptionOutcome> 
         ),
         aad_hash_hex: compute_aad_hash_hex(ttl)?,
         key_fragment,
+        salt_b64: salt.map(|s| URL_SAFE_NO_PAD.encode(s)),
     })
 }
 
 pub fn decrypt_local(payload_str: &str, key_b64: &str, ttl: u64) -> Result<Zeroizing<String>> {
+    decrypt_local_with_password(payload_str, key_b64, ttl, None, None)
+}
+
+pub fn decrypt_local_with_password(
+    payload_str: &str,
+    key_b64: &str,
+    ttl: u64,
+    password: Option<&str>,
+    salt_b64: Option<&str>,
+) -> Result<Zeroizing<String>> {
     let url_key = URL_SAFE_NO_PAD
         .decode(key_b64)
         .context("cle URL invalide")?;
@@ -126,7 +182,14 @@ pub fn decrypt_local(payload_str: &str, key_b64: &str, ttl: u64) -> Result<Zeroi
         bail!("nonce invalide");
     }
 
-    let final_key = derive_key(&url_key);
+    let final_key = match (password, salt_b64) {
+        (Some(pwd), Some(salt)) => {
+            let salt_bytes = URL_SAFE_NO_PAD.decode(salt).context("salt invalide")?;
+            derive_combined_key(&url_key, pwd, &salt_bytes)?
+        }
+        _ => derive_key(&url_key),
+    };
+
     let cipher = Aes256Gcm::new_from_slice(&final_key).context("erreur AES")?;
     let aad_bytes = build_aad(ttl)?;
     let plaintext = cipher
@@ -243,7 +306,8 @@ mod tests {
     fn encrypt_then_decrypt_roundtrip() {
         let message =
             r#"{"protocol":"ITYLOS_CAPSULE_V3_MULTI","message":"bonjour","attachments":[]}"#;
-        let encrypted = encrypt_local(message, 3600).expect("encryption should work");
+        let encrypted =
+            encrypt_local_with_password(message, 3600, None).expect("encryption should work");
         let decrypted =
             decrypt_local(&encrypted.payload, &encrypted.key_fragment, 3600).expect("decrypt");
         assert_eq!(&*decrypted, message);
@@ -260,10 +324,47 @@ mod tests {
     }
 
     #[test]
+    fn encrypt_then_decrypt_roundtrip_with_password() {
+        let message =
+            r#"{"protocol":"ITYLOS_CAPSULE_V3_MULTI","message":"confidentiel","attachments":[]}"#;
+        let encrypted = encrypt_local_with_password(message, 3600, Some("hunter2"))
+            .expect("encryption with password should work");
+        assert!(encrypted.salt_b64.is_some());
+
+        // Decrypt with correct password
+        let decrypted = decrypt_local_with_password(
+            &encrypted.payload,
+            &encrypted.key_fragment,
+            3600,
+            Some("hunter2"),
+            encrypted.salt_b64.as_deref(),
+        )
+        .expect("decrypt with correct password");
+        assert_eq!(&*decrypted, message);
+
+        // Decrypt with wrong password should fail
+        let error = decrypt_local_with_password(
+            &encrypted.payload,
+            &encrypted.key_fragment,
+            3600,
+            Some("wrong"),
+            encrypted.salt_b64.as_deref(),
+        )
+        .expect_err("wrong password should fail");
+        assert!(error.to_string().contains("dechiffrement echoue"));
+
+        // Decrypt without password should fail
+        let error2 = decrypt_local(&encrypted.payload, &encrypted.key_fragment, 3600)
+            .expect_err("missing password should fail");
+        assert!(error2.to_string().contains("dechiffrement echoue"));
+    }
+
+    #[test]
     fn decrypt_rejects_wrong_ttl() {
         let message =
             r#"{"protocol":"ITYLOS_CAPSULE_V3_MULTI","message":"bonjour","attachments":[]}"#;
-        let encrypted = encrypt_local(message, 3600).expect("encryption should work");
+        let encrypted =
+            encrypt_local_with_password(message, 3600, None).expect("encryption should work");
         let error = decrypt_local(&encrypted.payload, &encrypted.key_fragment, 86_400)
             .expect_err("ttl mismatch should fail");
         assert!(error.to_string().contains("dechiffrement echoue"));

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,7 @@ pub enum ItylosError {
     InvalidSecretId,
     #[error("TTL absent dans la reponse serveur - dechiffrement impossible.")]
     MissingTtl,
+    #[cfg(test)]
     #[error(
         "Cette capsule est protegee par mot de passe. Ouvrez ce lien dans votre navigateur pour la dechiffrer."
     )]

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,14 +61,21 @@ fn run() -> Result<()> {
             text,
             duration,
             file,
+            password,
         } => {
             let api = ItylosApi::new()?;
+            let pwd = if password {
+                Some(ui::prompt_new_password()?)
+            } else {
+                None
+            };
             send_secret(
                 &api,
                 SendOptions {
                     text: text.unwrap_or_default(),
                     file,
                     ttl: Ttl::parse(&duration),
+                    password: pwd,
                 },
             )?;
         }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -82,7 +82,13 @@ fn handle_tool_call(api: &ItylosApi, request: &Value) -> Value {
         return error_response("Erreur: Le texte du secret est vide.");
     }
 
-    match services::create_capsule_link(api, text.to_string(), None, crate::types::Ttl::OneHour) {
+    match services::create_capsule_link(
+        api,
+        text.to_string(),
+        None,
+        crate::types::Ttl::OneHour,
+        None,
+    ) {
         Ok(link) => json!({
             "content": [{ "type": "text", "text": format!("Capsule creee avec succes : {link}") }]
         }),

--- a/src/services.rs
+++ b/src/services.rs
@@ -17,8 +17,17 @@ use crate::{
 };
 
 pub fn send_secret(api: &ItylosApi, options: SendOptions) -> Result<()> {
-    let link = create_capsule_link(api, options.text, options.file.clone(), options.ttl)?;
+    let link = create_capsule_link(
+        api,
+        options.text,
+        options.file.clone(),
+        options.ttl,
+        options.password.as_deref(),
+    )?;
     ui::print_link(&link);
+    if options.password.is_some() {
+        ui::print_password_reminder();
+    }
     Ok(())
 }
 
@@ -27,24 +36,26 @@ pub fn create_capsule_link(
     text: String,
     file: Option<PathBuf>,
     ttl: Ttl,
+    password: Option<&str>,
 ) -> Result<String> {
     let capsule = build_capsule(text, file)?;
     let capsule_json = serde_json::to_string(&capsule).context("Erreur de serialisation")?;
-    let encrypted = crypto::encrypt_local(&capsule_json, ttl.seconds())?;
+    let encrypted = crypto::encrypt_local_with_password(&capsule_json, ttl.seconds(), password)?;
+    let has_password = encrypted.salt_b64.is_some();
     validate_create_request_parts(
         &encrypted.payload,
         ttl.seconds(),
         &encrypted.aad_hash_hex,
-        false,
-        None,
+        has_password,
+        encrypted.salt_b64.as_deref(),
     )?;
 
     let response = api.create_secret(&CreateReq {
         payload: encrypted.payload,
         ttl: normalize_ttl(ttl.seconds()),
         aad_hash: encrypted.aad_hash_hex,
-        has_password: false,
-        pwd_salt: None,
+        has_password,
+        pwd_salt: encrypted.salt_b64,
     })?;
 
     if !response.success {
@@ -60,13 +71,26 @@ pub fn create_capsule_link(
 pub fn read_secret(api: &ItylosApi, url: &str) -> Result<()> {
     let (secret_id, key_fragment) = parse_secret_url(url)?;
     let response = api.fetch_secret(&secret_id)?;
-    validate_fetch_response(&response)?;
+    validate_fetch_response_pre_password(&response)?;
 
     let payload = response
         .payload
         .as_deref()
         .ok_or_else(|| ItylosError::Message("payload absent".to_string()))?;
-    let decrypted = crypto::decrypt_local(payload, &key_fragment, response.ttl)?;
+
+    let decrypted = if response.has_password {
+        let password = ui::prompt_password()?;
+        crypto::decrypt_local_with_password(
+            payload,
+            &key_fragment,
+            response.ttl,
+            Some(&password),
+            response.pwd_salt.as_deref(),
+        )?
+    } else {
+        crypto::decrypt_local(payload, &key_fragment, response.ttl)?
+    };
+
     ui::print_decrypted_header();
     render_capsule(&decrypted)?;
     ui::print_decrypted_footer();
@@ -154,7 +178,16 @@ fn parse_secret_url(url: &str) -> Result<(String, String)> {
     Ok((secret_id, key_fragment.to_string()))
 }
 
+#[cfg(test)]
 fn validate_fetch_response(response: &FetchRes) -> Result<()> {
+    validate_fetch_response_pre_password(response)?;
+    if response.has_password {
+        return Err(ItylosError::PasswordProtected.into());
+    }
+    Ok(())
+}
+
+fn validate_fetch_response_pre_password(response: &FetchRes) -> Result<()> {
     if !response.success {
         bail!(
             response
@@ -177,9 +210,6 @@ fn validate_fetch_response(response: &FetchRes) -> Result<()> {
         response.has_password,
         response.pwd_salt.as_deref(),
     )?;
-    if response.has_password {
-        return Err(ItylosError::PasswordProtected.into());
-    }
     Ok(())
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-pub const VERSION: &str = "v2.0.2";
+pub const VERSION: &str = "v2.0.3";
 pub const DOMAIN: &str = "https://itylos.com";
 pub const API_CREATE: &str = "https://itylos.com/api/v2/create_secret";
 pub const API_FETCH: &str = "https://itylos.com/api/v2/fetch_secret";
@@ -139,6 +139,7 @@ pub struct SendOptions {
     pub text: String,
     pub file: Option<PathBuf>,
     pub ttl: Ttl,
+    pub password: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -227,3 +227,44 @@ pub fn print_file_extracted(name: &str, size: usize) {
         size
     );
 }
+
+pub fn print_password_reminder() {
+    println!(
+        "  {} {}",
+        "\u{26A0}".yellow().bold(),
+        "Le destinataire devra saisir le mot de passe pour d\u{00E9}chiffrer cette capsule."
+            .dimmed()
+    );
+}
+
+pub fn prompt_password() -> anyhow::Result<String> {
+    println!(
+        "\n  {} Cette capsule est prot\u{00E9}g\u{00E9}e par mot de passe.",
+        "\u{1F512}".bold()
+    );
+    let password = console::Term::stderr()
+        .read_secure_line()
+        .map_err(|_| anyhow::anyhow!("Impossible de lire le mot de passe"))?;
+    if password.is_empty() {
+        anyhow::bail!("Mot de passe requis pour d\u{00E9}chiffrer cette capsule.");
+    }
+    Ok(password)
+}
+
+pub fn prompt_new_password() -> anyhow::Result<String> {
+    eprint!("  Mot de passe pour la capsule : ");
+    let password = console::Term::stderr()
+        .read_secure_line()
+        .map_err(|_| anyhow::anyhow!("Impossible de lire le mot de passe"))?;
+    if password.is_empty() {
+        anyhow::bail!("Le mot de passe ne peut pas \u{00EA}tre vide.");
+    }
+    eprint!("  Confirmer le mot de passe : ");
+    let confirm = console::Term::stderr()
+        .read_secure_line()
+        .map_err(|_| anyhow::anyhow!("Impossible de lire la confirmation"))?;
+    if password != confirm {
+        anyhow::bail!("Les mots de passe ne correspondent pas.");
+    }
+    Ok(password)
+}


### PR DESCRIPTION
## Summary

Capsules can now be encrypted with an additional password layer, compatible with the web frontend (crypto.js).

### Usage

```bash
# Send with password
itylos send "secret" -p
itylos send -f document.pdf -d 24h --password

# Read (prompt if password-protected)
itylos read https://itylos.com/v/<id>#<key>
```

The CLI prompts interactively for the password (with confirmation on send, hidden input on read).

## Crypto contract (compatible with crypto.js)

```
salt       = 16 bytes random (sent to server as pwd_salt in base64url)
pwd_key    = PBKDF2-HMAC-SHA256(password, salt, 300000 iterations, 256 bits)
final_key  = SHA-256(url_key || pwd_key)
```

Without password: `final_key = SHA-256(url_key)` (unchanged, fully backward compatible).

## Files changed

- `Cargo.toml` / `Cargo.lock` — add `hmac` + `pbkdf2`, bump to 2.0.3
- `src/cli.rs` — add `-p` / `--password` flag to Send
- `src/crypto/mod.rs` — `derive_password_key`, `derive_combined_key`, `generate_salt`, password variants of encrypt/decrypt
- `src/services.rs` — propagate password through send/read flows
- `src/types.rs` — add `password` to `SendOptions`, bump VERSION
- `src/ui.rs` — `prompt_password`, `prompt_new_password`, `print_password_reminder`
- `src/main.rs` — pass password from CLI to send flow
- `src/mcp/mod.rs` — pass `None` for password (MCP doesn't support interactive prompts)
- `src/error.rs` — `PasswordProtected` now test-only

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — **30/30 tests** pass (new: `encrypt_then_decrypt_roundtrip_with_password`)
- [x] Password roundtrip: correct password decrypts, wrong password fails, no password fails

Authored by: Julien GELEE (@Krigsexe)